### PR TITLE
(AE-1450) Ensuring HDFValidator checks states against state_mappings.py PARAMETER_CORRECTIONS

### DIFF
--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -554,15 +554,16 @@ def validate_values_mapping(hdf, parameter, states=False):
     LOGGER.info("Checking parameter states and checking the validity: states")
     if states:
         for pattern, states in PARAMETER_CORRECTIONS.items():
-            for parameter_name in wildcard_match(pattern, [parameter.name]):
-                if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
-                    LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
-                                 "the states should be %s.",
-                                 parameter.name, parameter.values_mapping, states)
-                    break
-                else:
-                    continue
-            break
+            if wildcard_match(pattern, [parameter.name]):
+                for parameter_name in wildcard_match(pattern, [parameter.name]):
+                    if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
+                        LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
+                                     "the states should be %s.",
+                                     parameter.name, parameter.values_mapping, states)
+                        break
+                    else:
+                        continue
+                break
 
 
 def validate_dataset(hdf, name, parameter):


### PR DESCRIPTION
Changed validate_values_mapping() so it checks if the states are correct for all parameters. Before it was checking if the state mappings are correct only for the first parameter from the list as there was a 'break' statement executing after this. This was meant to stop the for loop after the current parameter was found in the PARAMETER_CORRECTIONS list.

Example flight: nax:4f71d0a8cf44 - 'AT Limit' state should be 'Engaged' not 'Limit'