### PR TITLE
(AE-1450) Ensuring HDFValidator checks states against state_mappings.py PARAMETER_CORRECTIONS

### DIFF
--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -561,9 +561,9 @@ def validate_values_mapping(hdf, parameter, states=False):
                              parameter.name, parameter.values_mapping, states) 
         else:
             for pattern, states in PARAMETER_CORRECTIONS.items():
-                found_matches=wildcard_match(pattern, [parameter.name])
+                found_matches = wildcard_match(pattern, [parameter.name])
                 if found_matches is not None and len(found_matches) > 0:
-                    for parameter_name in wildcard_match(pattern, [parameter.name]):
+                    for parameter_name in found_matches:
                         if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
                             LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
                                          "the states should be %s.",

--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -553,17 +553,24 @@ def validate_values_mapping(hdf, parameter, states=False):
 
     LOGGER.info("Checking parameter states and checking the validity: states")
     if states:
-        for pattern, states in PARAMETER_CORRECTIONS.items():
-            if wildcard_match(pattern, [parameter.name]):
-                for parameter_name in wildcard_match(pattern, [parameter.name]):
-                    if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
-                        LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
-                                     "the states should be %s.",
-                                     parameter.name, parameter.values_mapping, states)
-                        break
-                    else:
-                        continue
-                break
+        if not '(' in parameter.name or not ')' in parameter.name:
+            states = PARAMETER_CORRECTIONS.get(parameter.name)
+            if states and {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
+                LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
+                             "the states should be %s.",
+                             parameter.name, parameter.values_mapping, states) 
+        else:
+            for pattern, states in PARAMETER_CORRECTIONS.items():
+                if wildcard_match(pattern, [parameter.name]):
+                    for parameter_name in wildcard_match(pattern, [parameter.name]):
+                        if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
+                            LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
+                                         "the states should be %s.",
+                                         parameter.name, parameter.values_mapping, states)
+                            break
+                        else:
+                            continue
+                    break
 
 
 def validate_dataset(hdf, name, parameter):
@@ -1099,6 +1106,10 @@ def main():
 
     LOGGER.setLevel(logging.DEBUG)
     LOGGER.debug("Arguments: %s", str(args))
+    
+    import datetime
+    print(datetime.datetime.time(datetime.datetime.now()))
+    
     try:
         validate_file(args.HDF5, args.helicopter, names=args.parameter, states=args.states)
     except StoppedOnFirstError:
@@ -1117,6 +1128,8 @@ def main():
     LOGGER.info(msg)
     if args.show_only_errors:
         print(msg)
+        
+    print(datetime.datetime.time(datetime.datetime.now()))
 
 if __name__ == '__main__':
     main()

--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -554,15 +554,16 @@ def validate_values_mapping(hdf, parameter, states=False):
     LOGGER.info("Checking parameter states and checking the validity: states")
     if states:
         for pattern, states in PARAMETER_CORRECTIONS.items():
-            for parameter_name in wildcard_match(pattern, [parameter.name]):
-                if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
-                    LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
-                                 "the states should be %s.",
-                                 parameter.name, parameter.values_mapping, states)
-                    break
-                else:
-                    continue
-            break
+            if wildcard_match(pattern, [parameter.name]):
+                for parameter_name in wildcard_match(pattern, [parameter.name]):
+                    if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
+                        LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "
+                                     "the states should be %s.",
+                                     parameter.name, parameter.values_mapping, states)
+                        break
+                    else:
+                        continue
+                break
 
 
 def validate_dataset(hdf, name, parameter):

--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -561,7 +561,8 @@ def validate_values_mapping(hdf, parameter, states=False):
                              parameter.name, parameter.values_mapping, states) 
         else:
             for pattern, states in PARAMETER_CORRECTIONS.items():
-                if wildcard_match(pattern, [parameter.name]):
+                found_matches=wildcard_match(pattern, [parameter.name])
+                if found_matches is not None and len(found_matches) > 0:
                     for parameter_name in wildcard_match(pattern, [parameter.name]):
                         if {k: v for k, v in parameter.values_mapping.items() if v != '-'} != states:
                             LOGGER.error("'values_mapping': '%s' does not contain valid states %s, "

--- a/hdfaccess/tools/hdfvalidator.py
+++ b/hdfaccess/tools/hdfvalidator.py
@@ -1106,10 +1106,6 @@ def main():
 
     LOGGER.setLevel(logging.DEBUG)
     LOGGER.debug("Arguments: %s", str(args))
-    
-    import datetime
-    print(datetime.datetime.time(datetime.datetime.now()))
-    
     try:
         validate_file(args.HDF5, args.helicopter, names=args.parameter, states=args.states)
     except StoppedOnFirstError:
@@ -1128,8 +1124,6 @@ def main():
     LOGGER.info(msg)
     if args.show_only_errors:
         print(msg)
-        
-    print(datetime.datetime.time(datetime.datetime.now()))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Changed validate_values_mapping() so it checks if the states are correct for all parameters. Before it was checking if the state mappings are correct only for the first parameter from the list as there was a 'break' statement executing after this. This was meant to stop the for loop after the current parameter was found in the PARAMETER_CORRECTIONS list.

Example flight: nax:4f71d0a8cf44 - 'AT Limit' state should be 'Engaged' not 'Limit'