### PR TITLE
Bugfix/dg/mapped array

### DIFF
--- a/tests/datatypes/test_array.py
+++ b/tests/datatypes/test_array.py
@@ -346,6 +346,17 @@ class TestMappedArray(unittest.TestCase):
         for raw, state in values_mapping.items():
             self.assertEqual(array.get_state_value(state), [raw])
 
+    def test_view_from_ndarray(self):
+        """
+        Making a MappedArray view from a ndarray should result in a
+        MappedArray with an empty values_mapping.
+        """
+        array = np.array([0, 0, 0, 0, 1, 1, 0, 0, 1, 0])
+        mapped_array = array.view(MappedArray)
+        np.testing.assert_array_equal(mapped_array.raw, array)
+        np.testing.assert_array_equal(mapped_array.mask, [False] * len(array))
+        self.assertDictEqual(mapped_array.values_mapping, {})
+
 
 class TestParameterSubmasks(unittest.TestCase):
     """Test ParameterSubmasks proxy."""


### PR DESCRIPTION
Fix bug in MappedArray

Taking a MappedArray view from a ndarray should create a default empty dict.
Updated __new__ and __array_finalize__ according to current docs.
I have not implemented __array_ufunc__ as it's not straightforward to decide what to do if a ufunc is applied on MappedArrays. For the mathematical operators, we would probably like to disable them, but there could be some useful ufuncs like np.equal.

Now MappedArray can be compared among themselves. They compare elementwise provided their resulting mapped values compare equal. If no map value provided for this element, it will default to its raw value. See unit tests for some examples.